### PR TITLE
fix(deploy): rewrite clean URLs to .html on Apache

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,2 +1,19 @@
 Require all granted
 Satisfy any
+
+# Docusaurus (trailingSlash: false) emits page.html files.
+# Map clean URLs like /infrastructure/xserver-api to the matching .html file.
+<IfModule mod_rewrite.c>
+  Options -MultiViews
+  RewriteEngine On
+  RewriteBase /
+
+  RewriteRule ^index\.html$ - [L]
+
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
+  RewriteRule ^ - [L]
+
+  RewriteCond %{REQUEST_FILENAME}.html -f
+  RewriteRule ^(.+?)/?$ $1.html [L]
+</IfModule>


### PR DESCRIPTION
## Summary
- Add Apache rewrite rules to `static/.htaccess` so clean URLs map to Docusaurus `.html` output files.

## Verification
- `yarn build` (`.htaccess` copied to `build/`)
- Confirmed `/infrastructure/xserver-api` returns 404 while `/infrastructure/xserver-api.html` works on production before fix

Fixes #58